### PR TITLE
(Jiyoon) FEAT: URL 리스트 표시 우선순위 및 중복 제거 로직 구현

### DIFF
--- a/backend/routes/urlLoad_routes.py
+++ b/backend/routes/urlLoad_routes.py
@@ -130,6 +130,24 @@ def get_urls_by_type(page_id, url_type=None):
     
     return urls
 
+def get_general_crawled_urls_sorted(page_id):
+    """일반 URL과 크롤링된 URL을 타입별로 정렬하여 가져오기 (general 먼저, 그 다음 crawled, 중복 제거)"""
+    general_urls = get_urls_by_type(page_id, 'general')
+    crawled_urls = get_urls_by_type(page_id, 'crawled')
+    
+    # general 타입의 URL들을 set으로 만들어서 중복 체크용으로 사용
+    general_url_set = {url['url'] for url in general_urls}
+    
+    # crawled 타입에서 general 타입과 중복되지 않는 URL만 필터링
+    filtered_crawled_urls = [url for url in crawled_urls if url['url'] not in general_url_set]
+    
+    # general 타입 먼저, 그 다음 중복 제거된 crawled 타입 순서로 합치기
+    all_urls = general_urls + filtered_crawled_urls
+    
+    print(f"URL 중복 제거 결과: general {len(general_urls)}개, crawled {len(crawled_urls)}개 -> 필터링된 crawled {len(filtered_crawled_urls)}개")
+    
+    return all_urls
+
 # 크롤링된 URL 목록 가져오기 (Firestore 버전) - crawled 타입만
 def get_urls_from_firebase(page_id):
     """크롤링된 URL만 가져오기 (type='crawled')"""
@@ -208,15 +226,15 @@ def get_all_saved_urls(page_id):
     print(f"Firestore에서 가져온 전체 URL 목록 ({page_id}): {len(urls)}개")
     return jsonify({"success": True, "urls": urls}), 200
 
-# 일반 URL과 크롤링된 URL 목록 불러오기 (document 제외)
+# 일반 URL과 크롤링된 URL 목록 불러오기 (document 제외, general 먼저)
 @url_load_bp.route('/get-general-crawled-urls/<page_id>', methods=['GET'])
 def get_general_crawled_urls(page_id):
-    """일반 URL과 크롤링된 URL 목록 (general, crawled 타입만)"""
-    general_urls = get_urls_by_type(page_id, 'general')
-    crawled_urls = get_urls_by_type(page_id, 'crawled')
+    """일반 URL과 크롤링된 URL 목록 (general 먼저, 그 다음 crawled 타입)"""
+    all_urls = get_general_crawled_urls_sorted(page_id)
     
-    # 두 리스트 합치기
-    all_urls = general_urls + crawled_urls
+    # 타입별 개수 계산
+    general_count = len([url for url in all_urls if url.get('type') == 'general'])
+    crawled_count = len([url for url in all_urls if url.get('type') == 'crawled'])
     
-    print(f"Firestore에서 가져온 일반+크롤링 URL 목록 ({page_id}): {len(all_urls)}개 (general: {len(general_urls)}, crawled: {len(crawled_urls)})")
+    print(f"Firestore에서 가져온 일반+크롤링 URL 목록 ({page_id}): {len(all_urls)}개 (general: {general_count}, crawled: {crawled_count})")
     return jsonify({"success": True, "urls": all_urls}), 200

--- a/frontend/src/api/UrlApi.js
+++ b/frontend/src/api/UrlApi.js
@@ -1,9 +1,9 @@
 import BASE_URL from "../config/url";  
 
-// 저장된 URL 목록 가져오기 (crawled 타입만)
+// 저장된 URL 목록 가져오기 (general 먼저, 그 다음 crawled 타입)
 export const fetchSavedUrls = async (pageId) => {
   try {
-    const response = await fetch(`${BASE_URL}/get-crawled-urls/${pageId}`, {
+    const response = await fetch(`${BASE_URL}/get-general-crawled-urls/${pageId}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -15,7 +15,7 @@ export const fetchSavedUrls = async (pageId) => {
 
     if (data.success) {
       const urls = Array.isArray(data.urls) ? data.urls : [];
-      console.log(`[fetchSavedUrls] 성공: ${urls.length}개 crawled URL 로드`);
+      console.log(`[fetchSavedUrls] 성공: ${urls.length}개 URL 로드 (general + crawled)`);
       return urls;
     } else {
       console.error('URL 목록 불러오기 실패:', data.error);

--- a/frontend/src/pages/DashBoardPage.js
+++ b/frontend/src/pages/DashBoardPage.js
@@ -419,25 +419,46 @@ const DashboardPage = () => {
         setLoading(true);
         loadedRef.current = true;
 
-        // 1. Firestore URL 실시간 구독 (urls 컬렉션 사용, crawled 타입만)
+        // 1. Firestore URL 실시간 구독 (urls 컬렉션 사용, general과 crawled 타입)
         const urlsRef = collection(db, "urls");
         const urlQuery = query(
             urlsRef, 
             where("page_id", "==", pageId),
-            where("type", "==", "crawled")
+            where("type", "in", ["general", "crawled"])
         );
         
         const unsubscribeUrls = onSnapshot(urlQuery, (snapshot) => {
             const urlArray = snapshot.docs.map(doc => doc.data());
-            // 클라이언트 사이드에서 timestamp 기준으로 정렬 (오래된 순)
-            urlArray.sort((a, b) => {
+            
+            // 타입별로 분리하여 정렬
+            const generalUrls = urlArray.filter(url => url.type === "general");
+            const crawledUrls = urlArray.filter(url => url.type === "crawled");
+            
+            // 각 타입 내에서 timestamp 기준으로 오름차순 정렬 (오래된 순)
+            generalUrls.sort((a, b) => {
                 const timestampA = a.timestamp?.toDate?.() || new Date(a.date || 0);
                 const timestampB = b.timestamp?.toDate?.() || new Date(b.date || 0);
-                return timestampA - timestampB; // 오름차순 정렬 (오래된 순)
+                return timestampA - timestampB;
             });
-            console.log("URL 실시간 업데이트:", urlArray.length);
-            setUploadedUrls(urlArray);
-            setUrlCount(urlArray.length);
+            
+            crawledUrls.sort((a, b) => {
+                const timestampA = a.timestamp?.toDate?.() || new Date(a.date || 0);
+                const timestampB = b.timestamp?.toDate?.() || new Date(b.date || 0);
+                return timestampA - timestampB;
+            });
+            
+            // general 타입의 URL들을 Set으로 만들어서 중복 체크용으로 사용
+            const generalUrlSet = new Set(generalUrls.map(url => url.url));
+            
+            // crawled 타입에서 general 타입과 중복되지 않는 URL만 필터링
+            const filteredCrawledUrls = crawledUrls.filter(url => !generalUrlSet.has(url.url));
+            
+            // general 먼저, 그 다음 중복 제거된 crawled 순서로 합치기
+            const sortedUrls = [...generalUrls, ...filteredCrawledUrls];
+            
+            console.log("URL 실시간 업데이트:", sortedUrls.length, `(general: ${generalUrls.length}, crawled: ${crawledUrls.length} -> 필터링된 crawled: ${filteredCrawledUrls.length})`);
+            setUploadedUrls(sortedUrls);
+            setUrlCount(sortedUrls.length);
         }, (error) => {
             console.error("URL Firestore 구독 에러:", error);
         });


### PR DESCRIPTION
### 🔧 URL 리스트 표시 로직 개선

**변경사항:**
- URL 리스트에서 `general` 타입을 최우선으로 표시
- `crawled` 타입과 `general` 타입 간 중복 URL 제거
- 문서 URL(`document` 타입) 표시 제외
- 오래된 순 정렬 적용

**주요 수정 파일:**
- `backend/routes/urlLoad_routes.py` - 중복 제거 및 정렬 로직 추가
- `frontend/src/api/UrlApi.js` - API 엔드포인트 변경
- `frontend/src/pages/DashBoardPage.js` - Firestore 쿼리 및 중복 제거 로직 추가

**결과:**
- AdminPage와 DashBoardPage에서 일관된 URL 표시
- General 타입 → 중복 제거된 Crawled 타입 순서로 표시
- 사용자 경험 개선 (중복 URL 제거, 명확한 우선순위)

**테스트 필요:**
- [x] URL 추가 후 올바른 순서로 표시되는지 확인
- [x] 중복 URL이 general에서만 표시되는지 확인
- [x] 문서 URL이 리스트에서 제외되는지 확인